### PR TITLE
Disable http-client auto discovery.

### DIFF
--- a/config/packages/httplug.yaml
+++ b/config/packages/httplug.yaml
@@ -4,13 +4,13 @@ httplug:
             preserve_header: true
 
     discovery:
-        client: 'auto'
+        client: 'httplug.client.meetup'
 
     clients:
-        app:
+        meetup:
             http_methods_client: true
             plugins:
                 - 'httplug.plugin.logger'
                 - 'httplug.plugin.redirect'
                 - add_host:
-                      host: "https://api.meetup.com"
+                      host: 'https://api.meetup.com'


### PR DESCRIPTION
Using the auto discovery client causes requests to be sent twice as can be seen in these screenshots taken from the same frontpage with fresh caches.

current configuration:
![screen shot 2017-11-12 at 11 44 12](https://user-images.githubusercontent.com/2952726/32698137-26003120-c7a0-11e7-8fbe-cf9d863a7e31.png)

modified configuration:
![screen shot 2017-11-12 at 11 46 28](https://user-images.githubusercontent.com/2952726/32698138-26207e94-c7a0-11e7-82c7-6b8e868253f5.png)
